### PR TITLE
Correct repo for browsing F-Droid packages

### DIFF
--- a/confs/fdroid.json
+++ b/confs/fdroid.json
@@ -46,10 +46,10 @@
 			"token": "privatetoken"
 		},
 		{
-			"name": "webpkgs",
+			"name": "jekyll-fdroid",
 			"prefix": "https://gitlab.com",
-			"path": "fdroid/fdroid-website-packages",
-			"aliases": ["pkgs"],
+			"path": "fdroid/jekyll-fdroid",
+			"aliases": ["j", jekyll"],
 			"token": "privatetoken"
 		},
 		{


### PR DESCRIPTION
We now do it [via a Jekyll plugin](https://gitlab.com/fdroid/admin/issues/8) which causes the [old repo to be deleted](https://gitlab.com/fdroid/admin/issues/9).

@mvdan Thank you for everything you've done for F-Droid and for still being available on mention!