### PR TITLE
join channels on demand when specified in Feeds but not in Chans

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ bot will connect to IRC.
 `chans` are the channels that the bot will join and listen for messages
 on.
 
-`feeds` is the subset of channels in `chans` that the bot will post
-activity feed items on, such as when a new issue is created.
+`feeds` are the channels that the bot will post activity feed items on,
+such as when a new issue is created. `feeds` channels which are not
+listed in `chans` will be joined temporarily for posting.
 
 Finally, `repos` are the repos that the bot will use. The `token` has to
 be populated with your Gitlab API token.

--- a/handlers.go
+++ b/handlers.go
@@ -88,10 +88,24 @@ func sendNotice(channel, categ, body string) {
 func sendNotices(chans []string, categ, body string) {
 	message := fmt.Sprintf("[%s] %s", categ, body)
 	for _, channel := range chans {
+		if !prejoinedChans[channel] {
+			throttle.Send(&irc.Message{
+				Command: irc.JOIN,
+				Params:  []string{channel},
+			})
+		}
+
 		throttle.Send(&irc.Message{
 			Command:  irc.NOTICE,
 			Params:   []string{channel},
 			Trailing: message,
 		})
+
+		if !prejoinedChans[channel] {
+			throttle.Send(&irc.Message{
+				Command: irc.PART,
+				Params:  []string{channel},
+			})
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -27,8 +27,9 @@ const listenAddr = ":9990"
 var (
 	configPath = flag.String("c", "gibot.json", "path to json config file")
 
-	repos map[string]*gitlab.Repo // by url
-	allRe *regexp.Regexp
+	repos          map[string]*gitlab.Repo // by url
+	prejoinedChans = make(map[string]bool) // by channel name, e.g. #i3
+	allRe          *regexp.Regexp
 
 	pathRegex = regexp.MustCompile("[a-zA-Z0-9]+/[a-zA-Z0-9]+")
 
@@ -117,8 +118,11 @@ func loadConfig(p string) error {
 	if config.Server == "" {
 		return fmt.Errorf("no server specified")
 	}
-	if len(config.Chans) < 1 {
-		return fmt.Errorf("no channels specified")
+	if len(config.Chans) < 1 && len(config.Feeds) < 1 {
+		return fmt.Errorf("no channels specified (need either chans or feeds)")
+	}
+	for _, c := range config.Chans {
+		prejoinedChans[c] = true
 	}
 	for _, r := range config.Repos {
 		if r.Name == "" {


### PR DESCRIPTION
That way, the bot can reside outside of the channel most of the time and only
join when required. This can reduce join/quit spam on low-volume repositories
when the bot is running on a machine which is auto-updated daily.