### PR TITLE
remove empty prefix for fdroid client

### DIFF
--- a/confs/fdroid.json
+++ b/confs/fdroid.json
@@ -14,7 +14,7 @@
 			"name": "client",
 			"prefix": "https://gitlab.com",
 			"path": "fdroid/fdroidclient",
-			"aliases": ["", "c", "fdroidclient"],
+			"aliases": ["c", "fdroidclient"],
 			"token": "privatetoken"
 		},
 		{


### PR DESCRIPTION
It mostly generates involuntary matches nowadays.